### PR TITLE
Upgrade LISF component

### DIFF
--- a/setuprun.sh
+++ b/setuprun.sh
@@ -261,6 +261,16 @@ if [[ $RUNCONFIG == *"lnd"* ]]; then
     echo "ERROR: DATA_LND directory not found [$DATA_LND]"
     exit 1
   fi
+  # check lis.config
+  metfsrc=$(grep "Met forcing sources:" $RUNDIR/lis.config || echo "")
+  if [[ "${metfsrc}" == *"NLDAS2"* ]]; then
+    if [[ "${metfsrc}" != *"NLDAS2 grib"* ]] && \
+       [[ "${metfsrc}" != *"NLDAS2 netcdf"* ]]; then
+      printf "\e[31mERROR: lis.config error in [Met forcing sources]\n"
+      printf "  [NLDAS2] must be replaced with [NLDAS2 grib] or [NLDAS2 netcdf]"
+      printf "\e[0m\n\n"
+    fi
+  fi
 fi
 
 # Copy executable to RUNDIR


### PR DESCRIPTION
* upgrade LISF to 12d02d2 (2024-11-08)
* add lis.config check for NLDAS2

Requires manually modifying existing use cases.

Bit-for-Bit reproducibility on Discover SLES12

```
SUCCESS: coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2 LIS_HIST_201403020000.d01.nc
SUCCESS: coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2 LIS_HIST_201403030000.d01.nc
SUCCESS: coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2 LIS_HIST_201405310000.d01.nc
SUCCESS: coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2 LIS_HIST_201406010000.d01.nc
SUCCESS: coupled_tuolumne.noahmp.nldas2 LIS_HIST_201510020000.d01.nc
SUCCESS: coupled_tuolumne.noahmp.nldas2 LIS_HIST_201510030000.d01.nc
SUCCESS: coupled_tuolumne.noahmp.nldas2 LIS_HIST_201510040000.d01.nc
```